### PR TITLE
MIDCAMP-280 Test all branches except prod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ php:
   - 5.5
 
 branches:
-  only:
-    - develop
+  except:
+    - prod
 
 mysql:
   database: drupal


### PR DESCRIPTION
Rather than limiting tests to develop branch, allow all branches except prod.
