### PR TITLE
Fix Behat test for menu links

### DIFF
--- a/tests/features/menus.feature
+++ b/tests/features/menus.feature
@@ -2,11 +2,14 @@
   Feature: Menu scenarios
 
     @midcamp-225 @main-menu
-    Scenario: Main menu links
+    Scenario Outline: Main menu links
       Given I am an anonymous user
       And I am on the homepage
-      Then I should see 4 "ul.menu--main-menu.menu.links li" elements
-      And the "ul.menu--main-menu.menu.links li:nth-child(1)" element should contain "Sponsors"
-      And the "ul.menu--main-menu.menu.links li:nth-child(2)" element should contain "Become a Sponsor"
-      And the "ul.menu--main-menu.menu.links li:nth-child(3)" element should contain "Submitted Sessions"
-      And the "ul.menu--main-menu.menu.links li:nth-child(4)" element should contain "2015 MidCamp"
+      Then I should see an "ul.menu--main-menu.menu.links" element
+      And the "ul.menu--main-menu.menu.links" element should contain "<menu title>"
+    Examples:
+    | menu title         |
+    | Sponsors           |
+    | Become a Sponsor   |
+    | Submitted Sessions |
+    | 2015 MidCamp       |


### PR DESCRIPTION
- Allows for variable number of menu items
- Refactors menu title test to use an outline
