### PR TITLE
Community view: show names

### DIFF
--- a/docroot/sites/all/modules/features/build/midcamp_views/midcamp_views.views_default.inc
+++ b/docroot/sites/all/modules/features/build/midcamp_views/midcamp_views.views_default.inc
@@ -952,6 +952,25 @@ function midcamp_views_views_default_views() {
   $handler->display->display_options['fields']['uid']['label'] = '';
   $handler->display->display_options['fields']['uid']['exclude'] = TRUE;
   $handler->display->display_options['fields']['uid']['element_label_colon'] = FALSE;
+  /* Field: User: Full Name */
+  $handler->display->display_options['fields']['field_name']['id'] = 'field_name';
+  $handler->display->display_options['fields']['field_name']['table'] = 'field_data_field_name';
+  $handler->display->display_options['fields']['field_name']['field'] = 'field_name';
+  $handler->display->display_options['fields']['field_name']['ui_name'] = 'User: Full Name';
+  $handler->display->display_options['fields']['field_name']['label'] = '';
+  $handler->display->display_options['fields']['field_name']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_name']['click_sort_column'] = 'title';
+  $handler->display->display_options['fields']['field_name']['settings'] = array(
+    'format' => 'default',
+    'markup' => 0,
+    'output' => 'default',
+    'multiple' => 'default',
+    'multiple_delimiter' => ', ',
+    'multiple_and' => 'text',
+    'multiple_delimiter_precedes_last' => 'never',
+    'multiple_el_al_min' => '3',
+    'multiple_el_al_first' => '1',
+  );
   /* Field: User: Name */
   $handler->display->display_options['fields']['name_1']['id'] = 'name_1';
   $handler->display->display_options['fields']['name_1']['table'] = 'users';

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -215,4 +215,26 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     $this->assertSession()->elementNotContains('css', 'h2.pane-title', $text);
   }
 
+  /**
+   * Sets user's full name (given and family).
+   *
+   * @When user :username has given name :given and family name :family
+   *
+   * @param string $username
+   *   The user's username.
+   * @param string $given
+   *   The user's given (first) name.
+   * @param string $family
+   *   The user's family (last) name.
+   */
+  public function setFullName($username, $given, $family) {
+    $field_full_name = array(
+      'given' => $given,
+      'family' => $family,
+    );
+    $user = user_load_by_name($username);
+    $uw = entity_metadata_wrapper('user', $user);
+    $uw->field_name = $field_full_name;
+    $uw->save();
+  }
 }

--- a/tests/features/community.feature
+++ b/tests/features/community.feature
@@ -6,5 +6,7 @@ Feature: Test Community page
     Given users:
       | name         | pass  | mail                   | roles              |
       | jsession     | behat | joesession@example.com | authenticated user |
+    And user "jsession" has given name "Joe" and family name "Session"
     When I am at "/community"
     Then I should see the link "jsession"
+    And I should see the text "Joe Session"


### PR DESCRIPTION
- Updates /community view to display a person's full name
- Adds a test to check that the full name is displayed on /community view for a newly created user
