### PR TITLE
Midcamp 287 - Create a filterable view of accepted sessions

### DIFF
--- a/docroot/sites/all/modules/features/build/midcamp_views/midcamp_views.views_default.inc
+++ b/docroot/sites/all/modules/features/build/midcamp_views/midcamp_views.views_default.inc
@@ -4172,6 +4172,7 @@ function midcamp_views_views_default_views() {
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'role';
   $handler->display->display_options['access']['role'] = array(
+    1 => '1',
     7 => '7',
   );
   $handler->display->display_options['cache']['type'] = 'none';

--- a/docroot/sites/all/modules/features/build/midcamp_views/midcamp_views.views_default.inc
+++ b/docroot/sites/all/modules/features/build/midcamp_views/midcamp_views.views_default.inc
@@ -4423,7 +4423,6 @@ function midcamp_views_views_default_views() {
   $handler = $view->new_display('page', 'Accepted Page', 'page_1');
   $handler->display->display_options['defaults']['title'] = FALSE;
   $handler->display->display_options['title'] = 'Accepted Sessions';
-  $handler->display->display_options['enabled'] = FALSE;
   $handler->display->display_options['defaults']['header'] = FALSE;
   /* Header: Global: Text area */
   $handler->display->display_options['header']['area']['id'] = 'area';

--- a/tests/features/session_proposals.feature
+++ b/tests/features/session_proposals.feature
@@ -94,3 +94,22 @@ Feature: Session proposal functionality
     And I visit "users/joe-session1"
     Then I should not see "Session proposals"
     And I should not see "Drupal 101"
+
+  @midcamp-287
+  Scenario: Users can view accepted sessions
+
+    Given users:
+      | name         | pass  | mail                    | roles              |
+      | Joe Session1 | behat | joesession1@example.com | authenticated user |
+      | Joe Session2 | behat | joesession2@example.com | authenticated user |
+    And session content:
+      | title      | author       | field_drupal_specific | field_beginners | field_track   | field_length | field_attendee_description |
+      | Drupal 101 | Joe Session1 | Yes                   | Yes             | Site Building | 60 minutes   | Build something amazing    |
+      | Drupal 403 | Joe Session2 | Yes                   | No              | Site Building | 60 minutes   | Build something broken     |
+    And I am logged in as a user with the administrator role
+    And I visit "session-submissions"
+    And I click "Accept this session" in the "Drupal 101" row
+    When I am an anonymous user
+    And I visit "sessions"
+    Then I should see the link "Drupal 101"
+    And I should not see the link "Drupal 403"


### PR DESCRIPTION
Enables the existing view of accepted sessions, and allows anonymous users to view it. Also, adds tests to make sure that only accepted sessions are shown in the view.
